### PR TITLE
Update JSON schema file url

### DIFF
--- a/.github/workflows/check-taskfiles.yml
+++ b/.github/workflows/check-taskfiles.yml
@@ -48,10 +48,10 @@ jobs:
 
       - name: Download JSON schema for Taskfiles
         id: download-schema
-        uses: carlosperate/download-file-action@v1
+        uses: carlosperate/download-file-action@v2
         with:
-          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
-          file-url: https://json.schemastore.org/taskfile.json
+          # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/taskfile.json
+          file-url: https://taskfile.dev/schema.json
           location: ${{ runner.temp }}/taskfile-schema
 
       - name: Install JSON schema validator


### PR DESCRIPTION
Update ` carlosperate/download-file-action` to version 2 and use the correct file url to download the JSON schema.
These changes are made to mirror the workflow template stored in the https://github.com/arduino/tooling-project-assets repository and to prevent this error from occurring:
```
schema /home/runner/work/_temp/taskfile-schema/taskfile.json is invalid
error: can't resolve reference https://taskfile.dev/schema.json from id #
Error: Process completed with exit code 1.
```