### PR TITLE
feat: support arm64 macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/node_modules/
+node_modules/
+build/

--- a/deps/build_libs.sh
+++ b/deps/build_libs.sh
@@ -18,13 +18,13 @@ else
   CROSS_COMPILER=$CC
   # CROSS_COMPILER_CXX=$CXX
 fi
-cd ${LIB_PATH}/libusb-1.0.28
+cd "${LIB_PATH}/libusb-1.0.28"
 LIBUSB_DIR=$(pwd)
 export LIBUSB_DIR
 ./configure --prefix="${PREFIX}" --with-pic --disable-udev --enable-static --disable-shared --host="${CROSS_COMPILE}"
 make distclean
 ./configure --prefix="${PREFIX}" --with-pic --disable-udev --enable-static --disable-shared --host="${CROSS_COMPILE}"
-make -j${NPROC}
+make -j"${NPROC}"
 make install
 
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
@@ -33,16 +33,16 @@ if [[ $CROSS_COMPILE == "x86_64-apple-darwin13" || $CROSS_COMPILE == "aarch64-ap
   export LIBUSB_1_0_CFLAGS=-I${PREFIX}/include/libusb-1.0
   export LIBUSB_1_0_LIBS="-L${PREFIX}/lib -lusb-1.0"
 fi
-cd ${LIB_PATH}/libusb-compat-0.1.8
+cd "${LIB_PATH}/libusb-compat-0.1.8"
 LIBUSB0_DIR=$(pwd)
 export LIBUSB0_DIR
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" ./configure --prefix="${PREFIX}" --enable-static --disable-shared --host="${CROSS_COMPILE}"
 make distclean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" ./configure --prefix="${PREFIX}" --enable-static --disable-shared --host="${CROSS_COMPILE}"
-make -j${NPROC}
+make -j"${NPROC}"
 make install
 
-cd ${LIB_PATH}/libftdi1-1.4
+cd "${LIB_PATH}/libftdi1-1.4"
 rm -rf build && mkdir build && cd build
 
 CMAKE_EXTRA_FLAG="-DSHAREDLIBS=OFF -DBUILD_TESTS=OFF -DPYTHON_BINDINGS=OFF -DEXAMPLES=OFF -DFTDI_EEPROM=OFF"
@@ -60,13 +60,13 @@ fi
 #make -j"$(nproc)"
 #make install
 
-cd ${LIB_PATH}/libelf-0.8.13
+cd "${LIB_PATH}/libelf-0.8.13"
 LIBELF_DIR=$(pwd)
 export LIBELF_DIR
 ./configure --disable-shared --host="$CROSS_COMPILE" --prefix="${PREFIX}"
 make distclean
 ./configure --disable-shared --host="$CROSS_COMPILE" --prefix="${PREFIX}"
-make -j${NPROC}
+make -j"${NPROC}"
 make install
 
 echo "*****************"
@@ -75,47 +75,47 @@ echo "*****************"
 
 export CPPFLAGS="-P"
 
-cd ${LIB_PATH}/ncurses-6.3
+cd "${LIB_PATH}/ncurses-6.3"
 NCURSES_DIR=$(pwd)
 export NCURSES_DIR
 
 ./configure "$EXTRAFLAGS" --target="$CROSS_COMPILE" --without-pthread --enable-database --enable-sp-funcs --enable-term-driver --without-shared --without-debug --without-ada --enable-termcap --without-manpages --without-progs --without-tests --host="$CROSS_COMPILE" --prefix="${PREFIX}"
 make distclean
 ./configure "$EXTRAFLAGS" --target="$CROSS_COMPILE" --without-pthread --enable-database --enable-sp-funcs --enable-term-driver --without-shared --without-debug --without-ada --enable-termcap --without-manpages --without-progs --without-tests --host="$CROSS_COMPILE" --prefix="${PREFIX}"
-make -j${NPROC}
+make -j"${NPROC}"
 make install.libs
 
-cd ${LIB_PATH}/readline-8.0
+cd "${LIB_PATH}/readline-8.0"
 READLINE_DIR=$(pwd)
 export READLINE_DIR
 ./configure --prefix="$PREFIX" --disable-shared --host="$CROSS_COMPILE"
 make distclean
 ./configure --prefix="$PREFIX" --disable-shared --host="$CROSS_COMPILE"
-make -j${NPROC}
+make -j"${NPROC}"
 make install-static
 
 if [[ $CROSS_COMPILE != "i686-w64-mingw32" && $CROSS_COMPILE != "x86_64-apple-darwin13" && $CROSS_COMPILE != "aarch64-apple-darwin" ]]; then
-  cd ${LIB_PATH}/eudev-3.2.10
+  cd "${LIB_PATH}/eudev-3.2.10"
   ./autogen.sh
   ./configure --enable-static --disable-gudev --disable-introspection --disable-shared --disable-blkid --disable-kmod --disable-manpages --prefix="$PREFIX" --host="${CROSS_COMPILE}"
   make distclean
   ./autogen.sh
   ./configure --enable-static --disable-gudev --disable-introspection --disable-shared --disable-blkid --disable-kmod --disable-manpages --prefix="$PREFIX" --host="${CROSS_COMPILE}"
-  make -j${NPROC}
+  make -j"${NPROC}"
   make install
 fi
 
-cd ${LIB_PATH}/hidapi-0.12.0
+cd "${LIB_PATH}/hidapi-0.12.0"
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 ./bootstrap
 ./configure --prefix="$PREFIX" --enable-static --disable-shared --host="$CROSS_COMPILE"
 make distclean
 ./bootstrap
 ./configure --prefix="$PREFIX" --enable-static --disable-shared --host="$CROSS_COMPILE"
-make -j${NPROC}
+make -j"${NPROC}"
 make install
 
-tar -xzf ${LIB_PATH}/libxml2-2.14.3.tar.gz -C /tmp && cd /tmp/libxml2-2.14.3
+tar -xzf "${LIB_PATH}/libxml2-2.14.3.tar.gz" -C /tmp && cd /tmp/libxml2-2.14.3
 ./autogen.sh --prefix="$PREFIX" --disable-shared --enable-static --without-python --without-iconv --host="$CROSS_COMPILE"
-make -j${NPROC}
+make -j"${NPROC}"
 make install

--- a/deps/build_libs.sh
+++ b/deps/build_libs.sh
@@ -3,7 +3,10 @@
 true # Dummy command required to prevent first ShellCheck directive from having global scope.
 
 # shellcheck disable=SC2153 # Fix false positive of ShellCheck rule SC2153.
-export PREFIX=/opt/lib/${CROSS_COMPILE}
+
+LIB_PATH=${LIB_PATH:-/opt/lib}
+NPROC=${NPROC:-"$(nproc)"}
+export PREFIX=${PREFIX:-/opt/lib/${CROSS_COMPILE}}
 
 if [ "$CROSS_COMPILER" == "" ]; then
   CROSS_COMPILER=${CROSS_COMPILE}-gcc
@@ -15,13 +18,13 @@ else
   CROSS_COMPILER=$CC
   # CROSS_COMPILER_CXX=$CXX
 fi
-cd /opt/lib/libusb-1.0.28
+cd ${LIB_PATH}/libusb-1.0.28
 LIBUSB_DIR=$(pwd)
 export LIBUSB_DIR
 ./configure --prefix="${PREFIX}" --with-pic --disable-udev --enable-static --disable-shared --host="${CROSS_COMPILE}"
 make distclean
 ./configure --prefix="${PREFIX}" --with-pic --disable-udev --enable-static --disable-shared --host="${CROSS_COMPILE}"
-make -j"$(nproc)"
+make -j${NPROC}
 make install
 
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
@@ -30,16 +33,16 @@ if [[ $CROSS_COMPILE == "x86_64-apple-darwin13" ]]; then
   export LIBUSB_1_0_CFLAGS=-I${PREFIX}/include/libusb-1.0
   export LIBUSB_1_0_LIBS="-L${PREFIX}/lib -lusb-1.0"
 fi
-cd /opt/lib/libusb-compat-0.1.8
+cd ${LIB_PATH}/libusb-compat-0.1.8
 LIBUSB0_DIR=$(pwd)
 export LIBUSB0_DIR
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" ./configure --prefix="${PREFIX}" --enable-static --disable-shared --host="${CROSS_COMPILE}"
 make distclean
 PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" ./configure --prefix="${PREFIX}" --enable-static --disable-shared --host="${CROSS_COMPILE}"
-make -j"$(nproc)"
+make -j${NPROC}
 make install
 
-cd /opt/lib/libftdi1-1.4
+cd ${LIB_PATH}/libftdi1-1.4
 rm -rf build && mkdir build && cd build
 
 CMAKE_EXTRA_FLAG="-DSHAREDLIBS=OFF -DBUILD_TESTS=OFF -DPYTHON_BINDINGS=OFF -DEXAMPLES=OFF -DFTDI_EEPROM=OFF"
@@ -57,13 +60,13 @@ fi
 #make -j"$(nproc)"
 #make install
 
-cd /opt/lib/libelf-0.8.13
+cd ${LIB_PATH}/libelf-0.8.13
 LIBELF_DIR=$(pwd)
 export LIBELF_DIR
 ./configure --disable-shared --host="$CROSS_COMPILE" --prefix="${PREFIX}"
 make distclean
 ./configure --disable-shared --host="$CROSS_COMPILE" --prefix="${PREFIX}"
-make -j"$(nproc)"
+make -j${NPROC}
 make install
 
 echo "*****************"
@@ -72,47 +75,48 @@ echo "*****************"
 
 export CPPFLAGS="-P"
 
-cd /opt/lib/ncurses-6.3
+cd ${LIB_PATH}/ncurses-6.3
 NCURSES_DIR=$(pwd)
 export NCURSES_DIR
 
 ./configure "$EXTRAFLAGS" --target="$CROSS_COMPILE" --without-pthread --enable-database --enable-sp-funcs --enable-term-driver --without-shared --without-debug --without-ada --enable-termcap --without-manpages --without-progs --without-tests --host="$CROSS_COMPILE" --prefix="${PREFIX}"
 make distclean
 ./configure "$EXTRAFLAGS" --target="$CROSS_COMPILE" --without-pthread --enable-database --enable-sp-funcs --enable-term-driver --without-shared --without-debug --without-ada --enable-termcap --without-manpages --without-progs --without-tests --host="$CROSS_COMPILE" --prefix="${PREFIX}"
-make -j"$(nproc)"
+make -j${NPROC}
 make install.libs
 
-cd /opt/lib/readline-8.0
+cd ${LIB_PATH}/readline-8.0
 READLINE_DIR=$(pwd)
 export READLINE_DIR
 ./configure --prefix="$PREFIX" --disable-shared --host="$CROSS_COMPILE"
 make distclean
 ./configure --prefix="$PREFIX" --disable-shared --host="$CROSS_COMPILE"
-make -j"$(nproc)"
+make -j${NPROC}
 make install-static
 
-if [[ $CROSS_COMPILE != "i686-w64-mingw32" && $CROSS_COMPILE != "x86_64-apple-darwin13" ]]; then
-  cd /opt/lib/eudev-3.2.10
+if [[ $CROSS_COMPILE != "i686-w64-mingw32" && $CROSS_COMPILE != "x86_64-apple-darwin13" && $CROSS_COMPILE != "aarch64-apple-darwin" ]]; then
+  cd ${LIB_PATH}/eudev-3.2.10
   ./autogen.sh
   ./configure --enable-static --disable-gudev --disable-introspection --disable-shared --disable-blkid --disable-kmod --disable-manpages --prefix="$PREFIX" --host="${CROSS_COMPILE}"
   make distclean
   ./autogen.sh
   ./configure --enable-static --disable-gudev --disable-introspection --disable-shared --disable-blkid --disable-kmod --disable-manpages --prefix="$PREFIX" --host="${CROSS_COMPILE}"
-  make -j"$(nproc)"
+  make -j${NPROC}
   make install
 fi
 
-cd /opt/lib/hidapi-0.12.0
+cd ${LIB_PATH}/hidapi-0.12.0
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+libtoolize
 ./bootstrap
 ./configure --prefix="$PREFIX" --enable-static --disable-shared --host="$CROSS_COMPILE"
 make distclean
 ./bootstrap
 ./configure --prefix="$PREFIX" --enable-static --disable-shared --host="$CROSS_COMPILE"
-make -j"$(nproc)"
+make -j${NPROC}
 make install
 
-tar -xzf /opt/lib/libxml2-2.14.3.tar.gz -C /tmp && cd /tmp/libxml2-2.14.3
+tar -xzf ${LIB_PATH}/libxml2-2.14.3.tar.gz -C /tmp && cd /tmp/libxml2-2.14.3
 ./autogen.sh --prefix="$PREFIX" --disable-shared --enable-static --without-python --without-iconv --host="$CROSS_COMPILE"
-make -j"$(nproc)"
+make -j${NPROC}
 make install

--- a/deps/build_libs.sh
+++ b/deps/build_libs.sh
@@ -29,7 +29,7 @@ make install
 
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 
-if [[ $CROSS_COMPILE == "x86_64-apple-darwin13" ]]; then
+if [[ $CROSS_COMPILE == "x86_64-apple-darwin13" || $CROSS_COMPILE == "aarch64-apple-darwin" ]]; then
   export LIBUSB_1_0_CFLAGS=-I${PREFIX}/include/libusb-1.0
   export LIBUSB_1_0_LIBS="-L${PREFIX}/lib -lusb-1.0"
 fi
@@ -51,7 +51,7 @@ if [[ $CROSS_COMPILE == "i686-w64-mingw32" ]]; then
   CMAKE_EXTRA_FLAG="$CMAKE_EXTRA_FLAG -DCMAKE_TOOLCHAIN_FILE=./cmake/Toolchain-i686-w64-mingw32.cmake"
 fi
 
-if [[ $CROSS_COMPILE == "x86_64-apple-darwin13" ]]; then
+if [[ $CROSS_COMPILE == "x86_64-apple-darwin13" || $CROSS_COMPILE == "aarch64-apple-darwin" ]]; then
   CMAKE_EXTRA_FLAG="$CMAKE_EXTRA_FLAG -DCMAKE_AR=$AR -DCMAKE_RANLIB=$RANLIB"
 fi
 
@@ -107,7 +107,6 @@ fi
 
 cd ${LIB_PATH}/hidapi-0.12.0
 export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
-libtoolize
 ./bootstrap
 ./configure --prefix="$PREFIX" --enable-static --disable-shared --host="$CROSS_COMPILE"
 make distclean

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# This scripts builds all dependencies in ./deps for macOS and places them in ./build/macos/dist.
+# It is intended to be used in a native macOS environment or github macos runner.
+# It requires the necessary build tools including pkg-config, autoconf, automake, libtool.
 
 set -ex
 

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"
+BASE_PATH=$(cd "${SCRIPT_PATH}/.." && pwd)
+cd ${BASE_PATH}
+
+mkdir -p ${BASE_PATH}/build/macos
+rm -rf ${BASE_PATH}/build/macos/*
+cp -r ${BASE_PATH}/deps ${BASE_PATH}/build/macos/deps
+mkdir -p ${BASE_PATH}/build/macos/dist
+
+LIB_PATH=${BASE_PATH}/build/macos/deps \
+PREFIX=${BASE_PATH}/build/macos/dist \
+CROSS_COMPILER=cc \
+CROSS_COMPILE=aarch64-apple-darwin \
+NPROC=8 \
+./deps/build_libs.sh
+

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -12,9 +12,8 @@ cp -r "${BASE_PATH}/deps" "${BASE_PATH}/build/macos/deps"
 mkdir -p "${BASE_PATH}/build/macos/dist"
 
 LIB_PATH=${BASE_PATH}/build/macos/deps \
-PREFIX=${BASE_PATH}/build/macos/dist \
-CROSS_COMPILER=cc \
-CROSS_COMPILE=aarch64-apple-darwin \
-NPROC=8 \
-./deps/build_libs.sh
-
+  PREFIX=${BASE_PATH}/build/macos/dist \
+  CROSS_COMPILER=cc \
+  CROSS_COMPILE=aarch64-apple-darwin \
+  NPROC=8 \
+  ./deps/build_libs.sh

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -4,12 +4,12 @@ set -ex
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"
 BASE_PATH=$(cd "${SCRIPT_PATH}/.." && pwd)
-cd ${BASE_PATH}
+cd "${BASE_PATH}"
 
-mkdir -p ${BASE_PATH}/build/macos
-rm -rf ${BASE_PATH}/build/macos/*
-cp -r ${BASE_PATH}/deps ${BASE_PATH}/build/macos/deps
-mkdir -p ${BASE_PATH}/build/macos/dist
+mkdir -p "${BASE_PATH}/build/macos"
+rm -rf "${BASE_PATH}/build/macos/*"
+cp -r "${BASE_PATH}/deps" "${BASE_PATH}/build/macos/deps"
+mkdir -p "${BASE_PATH}/build/macos/dist"
 
 LIB_PATH=${BASE_PATH}/build/macos/deps \
 PREFIX=${BASE_PATH}/build/macos/dist \


### PR DESCRIPTION
Add a build script that can be used on a native macOS system to statically build all dependencies in `./deps`. This could be useful for using those libraries in a macOS GitHub runner without the need for the cross-compiler container.